### PR TITLE
Treat non-error HTTP correctly

### DIFF
--- a/sdks/marketingsolutions_preview/criteo_api_marketingsolutions_preview/rest.py
+++ b/sdks/marketingsolutions_preview/criteo_api_marketingsolutions_preview/rest.py
@@ -213,7 +213,7 @@ class RESTClientObject(object):
             # log response body
             logger.debug("response body: %s", r.data)
 
-        if not 200 <= r.status <= 299:
+        if not 100 <= r.status <= 399:
             if r.status == 401:
                 raise UnauthorizedException(http_resp=r)
 


### PR DESCRIPTION
This pull request changes the way the `preview` SDK treats HTTP statuses of 100 through 399 so it accepts them instead of raising them as `ApiException()`.